### PR TITLE
feat: skip output if no changes

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,7 +35,7 @@ if (argv.help) {
 }
 
 let cwd = process.cwd();
-let tree1 = "head";
+let tree1 = "HEAD";
 let tree2 = "disk";
 
 // the last argument MIGHT be a directory

--- a/lib/PackageChange.js
+++ b/lib/PackageChange.js
@@ -121,17 +121,17 @@ class PackageChange {
     }
     const excludeMatches = micromatch([this.name], excludePatterns);
     const isExcluded = excludeMatches.length > 0;
+    const depChanges = this.getPrintableDependencyChanges();
+    if (hasPrinted || isExcluded || depChanges.length === 0) {
+      return;
+    }
     if (isExcluded) {
       message = `[excluded] ${message}`;
       color = "gray";
     }
     const prefix = `${parentPrefix}${char1}`;
     console.log(`${prefix} ${colorize(color, message)}`);
-    if (hasPrinted || isExcluded) {
-      return;
-    }
     this.printed[this.id] = true;
-    const depChanges = this.getPrintableDependencyChanges();
     depChanges.forEach((depChange, i) => {
       const isLastChild = i === depChanges.length - 1;
       depChange.print(

--- a/lib/PackageChange.js
+++ b/lib/PackageChange.js
@@ -122,7 +122,7 @@ class PackageChange {
     const excludeMatches = micromatch([this.name], excludePatterns);
     const isExcluded = excludeMatches.length > 0;
     const depChanges = this.getPrintableDependencyChanges();
-    if (hasPrinted || isExcluded || depChanges.length === 0) {
+    if (hasPrinted || depChanges.length === 0) {
       return;
     }
     if (isExcluded) {
@@ -131,6 +131,9 @@ class PackageChange {
     }
     const prefix = `${parentPrefix}${char1}`;
     console.log(`${prefix} ${colorize(color, message)}`);
+    if (isExcluded) {
+      return;
+    }
     this.printed[this.id] = true;
     depChanges.forEach((depChange, i) => {
       const isLastChild = i === depChanges.length - 1;


### PR DESCRIPTION
This stylistic change makes it simpler to run this command as a script
across several packages (like a monorepo) and only see output if there's
changes. Makes it simpler to use with tools like a Github Action for any
PR that has a package-lock modification across a monorepo -> we can skip
commenting on the PR if there's no changes.

This makes the tool a slightly more well behaved unix tool.

Drive by tweak the default commit-ish from "head" to "HEAD", git show
head doesn't work for me, but git show HEAD does on a linux box.